### PR TITLE
Update Kafka client, Gatling, and Scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,11 @@ organization := "com.github.mnogu"
 
 version := "0.1.2-SNAPSHOT"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.3"
 
 libraryDependencies ++= Seq(
-  "io.gatling" % "gatling-core" % "2.2.3" % "provided",
-  ("org.apache.kafka" % "kafka-clients" % "0.10.1.1")
+  "io.gatling" % "gatling-core" % "2.3.0" % "provided",
+  ("org.apache.kafka" % "kafka-clients" % "0.10.2.1")
     // Gatling contains slf4j-api
     .exclude("org.slf4j", "slf4j-api")
 )


### PR DESCRIPTION
We want these to match what is used by Vertx 3.5.x